### PR TITLE
Display authorization status of balance on account card

### DIFF
--- a/src/components/Form/DisplayField/DisplayField.tsx
+++ b/src/components/Form/DisplayField/DisplayField.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import {Theme, Typography, TypographyProps} from "@material-ui/core";
-import {makeStyles} from "@material-ui/core/styles";
+import React, {ReactNode} from 'react';
+import {Theme, Typography, TypographyProps} from '@material-ui/core';
+import {makeStyles} from '@material-ui/core/styles';
 
 interface DisplayFieldProps {
     label: string;
-    value: string;
+    value: ReactNode;
     labelTypographyProps?: TypographyProps;
     valueTypographyProps?: TypographyProps;
 }

--- a/src/components/Stellar/AccountCard.tsx
+++ b/src/components/Stellar/AccountCard.tsx
@@ -160,13 +160,16 @@ export default function AccountCard(props: Props) {
                                                                     balance: string,
                                                                     asset_code: string,
                                                                     asset_issuer: string,
-                                                                    limit: string
+                                                                    limit: string,
+                                                                    is_authorized: boolean
                                                                 }
                                                                 return (
                                                                     <DisplayField
                                                                         key={idx}
-                                                                        label={`${otherBalance.asset_code} - [ ${otherBalance.asset_issuer} ] - Limit: ${otherBalance.limit}`}
-                                                                        value={numeral(otherBalance.balance).format('0,0.0000000')}
+                                                                        label={`${otherBalance.asset_code} - [ ${otherBalance.asset_issuer} ]`}
+                                                                        value={
+                                                                            <pre>{numeral(otherBalance.balance).format('0,0.0000000') +
+                                                                            `\tLimit: ${otherBalance.limit} \tAuthorized: ${otherBalance.is_authorized}`}</pre>}
                                                                         labelTypographyProps={{
                                                                             style: {
                                                                                 color: props.getRandomColorForKey


### PR DESCRIPTION
When viewing the balances on the account card, display the authorization status of trustline.
This allows us to debug payment failure because of PAYMENT_SRC_NOT_AUTHORIZED better.